### PR TITLE
fix: typescript build error

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,6 +7,7 @@ import {
   IpcMainInvokeEvent,
   IpcRendererEvent,
 } from 'electron';
+import type { Objectish } from 'immer/dist/internal';
 
 enablePatches();
 
@@ -16,7 +17,7 @@ interface IChangePack {
   senderId?: number;
 }
 
-export function createSharedStore<T>(state: T) {
+export function createSharedStore<T extends Objectish>(state: T) {
   let innerState = state;
   let lastChange: IChangePack = { patches: [] };
   let listeners: ((state: T, description?: string) => void)[] = [];


### PR DESCRIPTION
This PR fixes the following Typescript build error when running `yarn run build`:

```
lib/index.ts(46,38): error TS2345: Argument of type 'T' is not assignable to parameter of type 'Objectish'.
  Type 'T' is not assignable to type 'AnySet'.
lib/index.ts(54,7): error TS2322: Type 'Objectish' is not assignable to type 'T'.
  'T' could be instantiated with an arbitrary type which could be unrelated to 'Objectish'.

Error: error occured in dts build
    at Worker.<anonymous> (/Users/jeff/Code/electron-shared-state/node_modules/tsup/dist/index.js:2067:22)
    at Worker.emit (node:events:513:28)
    at MessagePort.<anonymous> (node:internal/worker:236:53)
    at MessagePort.[nodejs.internal.kHybridDispatch] (node:internal/event_target:736:20)
    at MessagePort.exports.emitMessage (node:internal/per_context/messageport:23:28)
```