### PR TITLE
fix: move `immer` to "dependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,13 @@
   "peerDependencies": {
     "electron": "*"
   },
+  "dependencies": {
+    "immer": "^9.0.2"
+  },
   "devDependencies": {
     "@types/node": "^15.6.1",
     "electron": "13.6.6",
     "husky": "^6.0.0",
-    "immer": "^9.0.2",
     "is-ci": "^3.0.0",
     "mocha": "^8.4.0",
     "prettier": "^2.3.0",


### PR DESCRIPTION
Since `electron-shared-state` cannot function without `immer`, it should be a "dependency" (not "devDependency").